### PR TITLE
Added missing applications when starting this one

### DIFF
--- a/src/slacker.erl
+++ b/src/slacker.erl
@@ -9,7 +9,7 @@
 
 -export([start/0, stop/0]).
 
--define(DEPS, [crypto, asn1, public_key, ssl, inets, slacker]).
+-define(DEPS, [crypto, asn1, public_key, ssl, inets, idna, hackney, restc, slacker]).
 
 -spec start() -> ok.
 start() ->

--- a/test/slacker_tests.erl
+++ b/test/slacker_tests.erl
@@ -28,6 +28,12 @@ users_list_test() ->
     {_Ok, _Status, _Headers, Body} = slacker_user:list(Token),
     ?assertEqual(true, get_val(<<"ok">>, Body)).
 
+application_start_works_test() ->
+    slacker:start(),
+    Token = read_token(),
+    {_, _, _, Body} = slacker_user:get_presence(Token, "ipinak"),
+    ?assertEqual(false, get_val(<<"ok">>, Body)).
+
 %%% Internal functionality
 
 read_token() ->


### PR DESCRIPTION
This fixes the following exception when starting the application on the shell:

```
1> slacker:start().
2> slacker_user:get_presence("some-token-here", "ipinak").
** exception exit: {noproc,
                       {gen_server,call,
                           [hackney_manager,
                            {new_request,<0.77.0>,#Ref<0.0.5.684>,
                                {client,undefined,hackney_dummy_metrics,
                                    hackney_ssl_transport,"slack.com",443,<<"slack.com">>,[],
                                    nil,nil,nil,true,hackney_pool,5000,false,5,false,5,...}},
                            infinity]}}
     in function  gen_server:call/3 (gen_server.erl, line 212)
     in call from hackney_manager:init_request/1 (src/hackney_client/hackney_manager.erl, line 66)
     in call from hackney_manager:new_request/1 (src/hackney_client/hackney_manager.erl, line 56)
     in call from hackney_connect:socket_from_pool/4 (src/hackney_connect/hackney_connect.erl, line 183)
     in call from hackney_connect:connect/5 (src/hackney_connect/hackney_connect.erl, line 36)
     in call from hackney:request/5 (src/hackney_client/hackney.erl, line 321)
     in call from restc:request/7 (src/restc.erl, line 97)
```

