### PR TITLE
Fix long-standing (I think) bug in generating edoc for slacker_file.erl

### DIFF
--- a/src/slacker_file.erl
+++ b/src/slacker_file.erl
@@ -15,7 +15,7 @@
 info(Token, File, Options) ->
     slacker_request:send("files.info", [{"token", Token},{"file", File}], Options).
 
-%% @doc List & filter team files.
+%% @doc List and filter team files.
 %%
 %% Options can be:
 %% user: filter files created by a single user


### PR DESCRIPTION
I think that this bug was causing slacker_file.erl not to be generated.