### PR TITLE
(fix) #noticket Fix spec for fields()

### DIFF
--- a/src/spec.hrl
+++ b/src/spec.hrl
@@ -11,4 +11,4 @@
 
 -type field_title() :: atom() | title | value.
 -type field()       :: {field_title(), binary()}.
--type fields()      :: [field()].
+-type fields()      :: list(list(field())).


### PR DESCRIPTION
The spec for `fields()` is incorrect, and causes dialyzer to throw warnings when used correctly. Please see here:
https://github.com/julienXX/slacker/blob/master/src/slacker_rich_messages.erl#L50-L60.

As it currently stands, the spec states that `fields()` should be something like: `[{title, <<"blah">>, {value, <<"blah">>}, {title, <<"blah1">>, ...]`. Using it in this way causes a crash:
```
** exception error: no function clause matching proplists:get_value(title,{title,"User"},undefined) (proplists.erl, line 215)
     in function  slacker_rich_messages:format_field/1 (/opt/my_app/_build/default/lib/slacker/src/slacker_rich_messages.erl, line 58)
     in call from lists:map/2 (lists.erl, line 1239)
     in call from slacker_rich_messages:format_table/4 (/opt/my_app/_build/default/lib/slacker/src/slacker_rich_messages.erl, line 41)
     in call from my_app:build_message/4 (/opt/my_app/_build/default/lib/my_app/src/my_app_slack.erl, line 28)
     in call from my_app_slack:submit_slack_message/3 
```

When changing `fields()` to what I'm proposing, no errors in dialyzer or code happen. IE)
```
Fields = 
    [[{title, <<"User">>}, {value, UserName}],
     [{title, <<"Environment">>}, {value, Environment}]].
```